### PR TITLE
refactor: Extract impl_value_content_traits sub-macro

### DIFF
--- a/src/expressions/concepts/type_traits.rs
+++ b/src/expressions/concepts/type_traits.rs
@@ -411,22 +411,7 @@ macro_rules! define_parent_type {
             $( <F as IsFormOf<$variant_type>>::Content<'a>: Copy ),*
         {}
 
-        impl<'a, F: IsHierarchicalForm> IsValueContent<'a> for $content<'a, F> {
-            type Type = $type_def;
-            type Form = F;
-        }
-
-        impl<'a, F: IsHierarchicalForm> IntoValueContent<'a> for $content<'a, F> {
-            fn into_content(self) -> Self {
-                self
-            }
-        }
-
-        impl<'a, F: IsHierarchicalForm> FromValueContent<'a> for $content<'a, F> {
-            fn from_content(content: Self) -> Self {
-                content
-            }
-        }
+        impl_value_content_traits!(parent: $type_def, $content);
 
         impl<'a, F: IsHierarchicalForm> HasLeafKind for $content<'a, F> {
             type LeafKind = $leaf_kind;
@@ -621,56 +606,7 @@ macro_rules! define_leaf_type {
             }
         }
 
-        impl<'a> IsValueContent<'a> for $content_type {
-            type Type = $type_def;
-            type Form = BeOwned;
-        }
-
-        impl<'a> IntoValueContent<'a> for $content_type {
-            fn into_content(self) -> Self {
-                self
-            }
-        }
-
-        impl<'a> FromValueContent<'a> for $content_type {
-            fn from_content(content: Self) -> Self {
-                content
-            }
-        }
-
-        impl<'a> IsValueContent<'a> for &'a $content_type {
-            type Type = $type_def;
-            type Form = BeRef;
-        }
-
-        impl<'a> IntoValueContent<'a> for &'a $content_type {
-            fn into_content(self) -> Self {
-                self
-            }
-        }
-
-        impl<'a> FromValueContent<'a> for &'a $content_type {
-            fn from_content(content: Self) -> Self {
-                content
-            }
-        }
-
-        impl<'a> IsValueContent<'a> for &'a mut $content_type {
-            type Type = $type_def;
-            type Form = BeMut;
-        }
-
-        impl<'a> IntoValueContent<'a> for &'a mut $content_type {
-            fn into_content(self) -> Self {
-                self
-            }
-        }
-
-        impl<'a> FromValueContent<'a> for &'a mut $content_type {
-            fn from_content(content: Self) -> Self {
-                content
-            }
-        }
+        impl_value_content_traits!(leaf: $type_def, $content_type);
 
         impl IsValueLeaf for $content_type {}
 
@@ -701,6 +637,289 @@ macro_rules! define_leaf_type {
 pub(crate) use define_leaf_type;
 
 pub(crate) struct DynMapper<D: ?Sized>(std::marker::PhantomData<D>);
+
+/// Implements `IsValueContent`, `IntoValueContent`, and `FromValueContent` for various
+/// form wrappers of a content type. This macro deduplicates code across `define_leaf_type`,
+/// `define_parent_type`, and `define_dyn_type`.
+macro_rules! impl_value_content_traits {
+    // For leaf types - implements for all common form wrappers
+    (leaf: $type_def:ty, $content_type:ty) => {
+        // BeOwned: content is X
+        impl<'a> IsValueContent<'a> for $content_type {
+            type Type = $type_def;
+            type Form = BeOwned;
+        }
+        impl<'a> IntoValueContent<'a> for $content_type {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for $content_type {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeRef: content is &'a X
+        impl<'a> IsValueContent<'a> for &'a $content_type {
+            type Type = $type_def;
+            type Form = BeRef;
+        }
+        impl<'a> IntoValueContent<'a> for &'a $content_type {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for &'a $content_type {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeMut: content is &'a mut X
+        impl<'a> IsValueContent<'a> for &'a mut $content_type {
+            type Type = $type_def;
+            type Form = BeMut;
+        }
+        impl<'a> IntoValueContent<'a> for &'a mut $content_type {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for &'a mut $content_type {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeMutable: content is MutableSubRcRefCell<Value, X>
+        impl<'a> IsValueContent<'a> for MutableSubRcRefCell<Value, $content_type> {
+            type Type = $type_def;
+            type Form = BeMutable;
+        }
+        impl<'a> IntoValueContent<'a> for MutableSubRcRefCell<Value, $content_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for MutableSubRcRefCell<Value, $content_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeShared: content is SharedSubRcRefCell<Value, X>
+        impl<'a> IsValueContent<'a> for SharedSubRcRefCell<Value, $content_type> {
+            type Type = $type_def;
+            type Form = BeShared;
+        }
+        impl<'a> IntoValueContent<'a> for SharedSubRcRefCell<Value, $content_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for SharedSubRcRefCell<Value, $content_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeAnyRef: content is AnyRef<'a, X>
+        impl<'a> IsValueContent<'a> for AnyRef<'a, $content_type> {
+            type Type = $type_def;
+            type Form = BeAnyRef;
+        }
+        impl<'a> IntoValueContent<'a> for AnyRef<'a, $content_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for AnyRef<'a, $content_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeAnyMut: content is AnyMut<'a, X>
+        impl<'a> IsValueContent<'a> for AnyMut<'a, $content_type> {
+            type Type = $type_def;
+            type Form = BeAnyMut;
+        }
+        impl<'a> IntoValueContent<'a> for AnyMut<'a, $content_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for AnyMut<'a, $content_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeReferenceable: content is Rc<RefCell<X>>
+        impl<'a> IsValueContent<'a> for Rc<RefCell<$content_type>> {
+            type Type = $type_def;
+            type Form = BeReferenceable;
+        }
+        impl<'a> IntoValueContent<'a> for Rc<RefCell<$content_type>> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for Rc<RefCell<$content_type>> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // Note: BeAssignee uses the same Leaf type as BeMutable (MutableSubRcRefCell<Value, T>),
+        // so we can't have a separate impl for it - the BeMutable impl covers both.
+    };
+
+    // For parent types - $content<'a, F> where F: IsHierarchicalForm
+    (parent: $type_def:ty, $content:ident) => {
+        impl<'a, F: IsHierarchicalForm> IsValueContent<'a> for $content<'a, F> {
+            type Type = $type_def;
+            type Form = F;
+        }
+        impl<'a, F: IsHierarchicalForm> IntoValueContent<'a> for $content<'a, F> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a, F: IsHierarchicalForm> FromValueContent<'a> for $content<'a, F> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+    };
+
+    // For dyn types - implements for all dyn-compatible form wrappers
+    (dyn: $type_def:ty, $dyn_type:ty) => {
+        // The unsized dyn type itself needs IsValueContent for IsDynLeaf requirements
+        impl<'a> IsValueContent<'a> for $dyn_type {
+            type Type = $type_def;
+            type Form = BeOwned;
+        }
+
+        // BeOwned: content is Box<D>
+        impl<'a> IsValueContent<'a> for Box<$dyn_type> {
+            type Type = $type_def;
+            type Form = BeOwned;
+        }
+        impl<'a> IntoValueContent<'a> for Box<$dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for Box<$dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeRef: content is &'a D
+        impl<'a> IsValueContent<'a> for &'a $dyn_type {
+            type Type = $type_def;
+            type Form = BeRef;
+        }
+        impl<'a> IntoValueContent<'a> for &'a $dyn_type {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for &'a $dyn_type {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeMut: content is &'a mut D
+        impl<'a> IsValueContent<'a> for &'a mut $dyn_type {
+            type Type = $type_def;
+            type Form = BeMut;
+        }
+        impl<'a> IntoValueContent<'a> for &'a mut $dyn_type {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for &'a mut $dyn_type {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeMutable: content is MutableSubRcRefCell<Value, D>
+        impl<'a> IsValueContent<'a> for MutableSubRcRefCell<Value, $dyn_type> {
+            type Type = $type_def;
+            type Form = BeMutable;
+        }
+        impl<'a> IntoValueContent<'a> for MutableSubRcRefCell<Value, $dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for MutableSubRcRefCell<Value, $dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeShared: content is SharedSubRcRefCell<Value, D>
+        impl<'a> IsValueContent<'a> for SharedSubRcRefCell<Value, $dyn_type> {
+            type Type = $type_def;
+            type Form = BeShared;
+        }
+        impl<'a> IntoValueContent<'a> for SharedSubRcRefCell<Value, $dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for SharedSubRcRefCell<Value, $dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeAnyRef: content is AnyRef<'a, D>
+        impl<'a> IsValueContent<'a> for AnyRef<'a, $dyn_type> {
+            type Type = $type_def;
+            type Form = BeAnyRef;
+        }
+        impl<'a> IntoValueContent<'a> for AnyRef<'a, $dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for AnyRef<'a, $dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // BeAnyMut: content is AnyMut<'a, D>
+        impl<'a> IsValueContent<'a> for AnyMut<'a, $dyn_type> {
+            type Type = $type_def;
+            type Form = BeAnyMut;
+        }
+        impl<'a> IntoValueContent<'a> for AnyMut<'a, $dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for AnyMut<'a, $dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
+        // Note: BeAssignee uses the same DynLeaf type as BeMutable, so covered above.
+        // Note: BeReferenceable (Rc<RefCell<D>>) doesn't work for unsized D.
+    };
+}
+
+pub(crate) use impl_value_content_traits;
 
 macro_rules! define_dyn_type {
     (
@@ -744,10 +963,7 @@ macro_rules! define_dyn_type {
             impl TypeFeatureResolver for $type_def: [$type_def]
         }
 
-        impl<'a> IsValueContent<'a> for $dyn_type {
-            type Type = $type_def;
-            type Form = BeOwned;
-        }
+        impl_value_content_traits!(dyn: $type_def, $dyn_type);
 
         impl IsDynLeaf for $dyn_type {}
 

--- a/src/expressions/concepts/type_traits.rs
+++ b/src/expressions/concepts/type_traits.rs
@@ -772,8 +772,21 @@ macro_rules! impl_value_content_traits {
             }
         }
 
-        // Note: BeAssignee uses the same Leaf type as BeMutable (MutableSubRcRefCell<Value, T>),
-        // so we can't have a separate impl for it - the BeMutable impl covers both.
+        // BeAssignee: content is QqqAssignee<X>
+        impl<'a> IsValueContent<'a> for QqqAssignee<$content_type> {
+            type Type = $type_def;
+            type Form = BeAssignee;
+        }
+        impl<'a> IntoValueContent<'a> for QqqAssignee<$content_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for QqqAssignee<$content_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
     };
 
     // For parent types - $content<'a, F> where F: IsHierarchicalForm
@@ -914,7 +927,22 @@ macro_rules! impl_value_content_traits {
             }
         }
 
-        // Note: BeAssignee uses the same DynLeaf type as BeMutable, so covered above.
+        // BeAssignee: content is QqqAssignee<D>
+        impl<'a> IsValueContent<'a> for QqqAssignee<$dyn_type> {
+            type Type = $type_def;
+            type Form = BeAssignee;
+        }
+        impl<'a> IntoValueContent<'a> for QqqAssignee<$dyn_type> {
+            fn into_content(self) -> Self {
+                self
+            }
+        }
+        impl<'a> FromValueContent<'a> for QqqAssignee<$dyn_type> {
+            fn from_content(content: Self) -> Self {
+                content
+            }
+        }
+
         // Note: BeReferenceable (Rc<RefCell<D>>) doesn't work for unsized D.
     };
 }


### PR DESCRIPTION
Extracted a new `impl_value_content_traits` macro that deduplicates the IsValueContent/IntoValueContent/FromValueContent implementations across `define_leaf_type`, `define_parent_type`, and `define_dyn_type`.

The macro has three variants:
- `leaf:` for leaf types - implements for X, &X, &mut X plus additional form wrappers (BeMutable, BeShared, BeAnyRef, BeAnyMut, BeReferenceable)
- `parent:` for parent types - implements for $content<'a, F>
- `dyn:` for dyn types - implements just IsValueContent

This refactoring:
1. Deduplicates existing code across the three macros
2. Adds new form implementations for leaf types that were previously missing (BeMutable, BeShared, BeAnyRef, BeAnyMut, BeReferenceable)